### PR TITLE
Another API update

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -99,6 +99,11 @@ class ElasticSearchCheck(NagiosCheck):
         # Data retrieval
         #
 
+        # Request "about" info, so we can figure out the ES version,
+        # to allow for version-specific API changes.
+        es_about = get_json(r'http://%s:%d/' % (host, port))
+        es_version = es_about['version']['number']
+
         # Request cluster 'health'.  /_cluster/health is like a tl;dr 
         # for /_cluster/state (see below).  There is very little useful 
         # information here.  We are primarily interested in ES' cluster 
@@ -218,9 +223,14 @@ class ElasticSearchCheck(NagiosCheck):
         indices = es_state['metadata']['indices']
         for i in indices:
             idx_stns = indices[i]['settings']
-            idx = ESIndex(i,
-                          int(idx_stns['index.number_of_shards']),
-                          int(idx_stns['index.number_of_replicas']))
+            if version(es_version) < version("1.0.0"):
+                idx = ESIndex(i,
+                              int(idx_stns['index.number_of_shards']),
+                              int(idx_stns['index.number_of_replicas']))
+            else:
+                idx = ESIndex(i,
+                              int(idx_stns['index']['number_of_shards']),
+                              int(idx_stns['index']['number_of_replicas']))
 
             name_index_map[i] = idx
 
@@ -560,6 +570,11 @@ def get_json(uri):
         raise Status('unknown', ("API returned nonsense",))
 
     return j
+
+def version(version_string):
+    """Accept a typical version string (ex: 1.0.1) and return a tuple
+    of ints, allowing for reasonable comparison."""
+    return tuple([int(i) for i in version_string.split('.')])
 
 if __name__ == '__main__':
     ElasticSearchCheck().run()


### PR DESCRIPTION
Looks like there must've been a 1.0.0 API change to the index settings.  Mine look like this:

```
"index": {
    "number_of_replicas": "1",
    "number_of_shards": "5",
    "uuid": "lhsjBokSQoO7uSSbZ1vFWQ",
    "version": {
        "created": "1000099"
    }
}
```

Since the plugin asks for `[index.number_of_shards]` instead of `['index']['number_of_shards']`, this throws a KeyError on 1.0.0 servers.

My patch includes a version check so it should work just fine for older servers as well, but I have not actually been able to test it against a pre-1.0.0 server.
