### PR TITLE
Conform -vv output to Nagio's one-line output

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -523,7 +523,7 @@ class ElasticSearchCheck(NagiosCheck):
                          perfdata)
 
         raise Status(HEALTH_MAP[self.health],
-                     (msg, None, "%s\n\n%s" % (msg, "\n".join(detail))),
+                     (msg, None, "%s %s" % (msg, " ".join(detail))),
                      perfdata)
 
     def downgrade_health(self, new_health):


### PR DESCRIPTION
Conform -vv output to Nagio's one-line output requirement.
This allows for the shard / index in error to be properly displayed by Nagios / Check_MK
