### PR TITLE
Don't check closed elasticsearch indices

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -222,6 +222,8 @@ class ElasticSearchCheck(NagiosCheck):
         #
         indices = es_state['metadata']['indices']
         for i in indices:
+            if indices[i]["state"] == "close":
+                continue
             idx_stns = indices[i]['settings']
             if version(es_version) < version("1.0.0"):
                 idx = ESIndex(i,


### PR DESCRIPTION
Sometimes, we'll have elasticsearch indexes in the cluster which have
been closed (ie, data unloaded from memory, no access allowed except for
reopen or delete).  These will be deleted after a while.  Update the
nagios check to ignore such indices, since otherwise they'll give
spurious errors.
