### PR TITLE
Include RELOCATING state as a good state for replica shards

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -435,7 +435,7 @@ class ElasticSearchCheck(NagiosCheck):
                                   "shard %d" % (idx_name, shard_no))
 
                 for replica in primary_replica_map[primary]:
-                    if replica.state != SHARD_STATE['STARTED']:
+                    if replica.state not in ( SHARD_STATE['STARTED'], SHARD_STATE['RELOCATING'] ):
                         downgraded |= self.downgrade_health(YELLOW)
                         detail.append("Index '%s' replica down on "
                                       "shard %d" % (idx_name, shard_no))


### PR DESCRIPTION
When replica shards are relocating the check was failing because it thinks the shard is down, even though the cluster is green and it's just relocating.  The primary shard check looks for both the STARTED and RELOCATING state, and this change makes it so that the replica shard check behaves in the same way.
