### PR TITLE
Modified setup.py to be compatible with pip 6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-nagioscheck==0.1.6
-simplejson>=3.4.0
-setuptools>=3.4.0
-pip>=1.4
+--index-url https://pypi.python.org/simple/
+
+-e .

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pip.req import parse_requirements
 setup(
     name="nagios-plugin-elasticsearch",
     description="An ElasticSearch availability and performance monitoring plugin for Nagios.",
-    version="1.0.2",
+    version="1.0.3",
     packages=find_packages(),
     url="https://github.com/anchor/nagios-plugin-elasticsearch",
     maintainer="Sharif Olorin",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pip.req import parse_requirements
 setup(
     name="nagios-plugin-elasticsearch",
     description="An ElasticSearch availability and performance monitoring plugin for Nagios.",
-    version="1.0.3",
+    version="1.0.2",
     packages=find_packages(),
     url="https://github.com/anchor/nagios-plugin-elasticsearch",
     maintainer="Sharif Olorin",
@@ -15,7 +15,11 @@ setup(
     author_email="sg@redu.cx",
     scripts=["check_elasticsearch"],
     license="MIT",
-    install_requires=[str(req.req) for req in
-                          parse_requirements("requirements.txt")],
+    install_requires=[
+      'nagioscheck==0.1.6',
+      'simplejson>=3.4.0',
+      'setuptools>=3.4.0',
+      'pip>=1.4' 
+    ],
     include_package_data=True
 )


### PR DESCRIPTION
I had problems installing this check with pip 6.x

The problem is that parse_requirements function has changed (and there seems public doc is not available)

After googling a bit I found this:
http://stackoverflow.com/questions/14399534/how-can-i-reference-requirements-txt-for-the-install-requires-kwarg-in-setuptool
and this:
https://caremad.io/2013/07/setup-vs-requirement/

And modified the code accordingly, mind you I am not an expert in python/pip packaging.

