### PR TITLE
Add option to make a yellow condition issue a critical alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Options:
                         do not monitor the number of nodes in the cluster.
   -p PORT, --port=PORT  TCP port to probe.  The ElasticSearch API should be
                         listening here.  Defaults to 9200.
+  -y YELLOW_CRITICAL, --yellow-critical=TRUE
+                        Instead of issuing a 'warning' for a yellow cluster
+                        state, issue a 'critical' alert. Allows for greater
+                        control of alerting for clusters that may be of 
+                        greater sensitivity (or fragility). Defaults to False.
 
 ```
 

--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -89,6 +89,9 @@ class ElasticSearchCheck(NagiosCheck):
                         "Optional prefix (e.g. 'es') for the "
                         "ElasticSearch API. Defaults to ''.")
 
+        self.add_option('y', 'yellow-critical', 'yellow_critical',
+                        "Have plugin issue critical alert on yellow cluster state. Defaults to False.")
+
     def check(self, opts, args):
         host = opts.host or "localhost"
         port = int(opts.port or '9200')
@@ -110,6 +113,11 @@ class ElasticSearchCheck(NagiosCheck):
             except ValueError:
                 raise UsageError("Argument to -m/--master-nodes must "
                                  "be a natural number")
+
+        yellow_critical = opts.yellow_critical and opts.yellow_critical.lower() not in ('f', 'false', 'n', 'no')
+        if yellow_critical:
+            HEALTH_MAP[1] = 'critical'
+
         #
         # Data retrieval
         #


### PR DESCRIPTION
As per the title, we found ourselves wanting to configure check_elasticsearch to consider a yellow condition of the elasticsearch cluster as a critical alert. This PR adds that option as a CLI flag.