### PR TITLE
Fetch cluster stats, simplify n_mnodes calculation.

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -144,6 +144,11 @@ class ElasticSearchCheck(NagiosCheck):
         es_state = get_json(r'http://%s:%d/%s_cluster/state' %
                             (host, port, prefix))
 
+        # Request cluster 'stats'.  We're primarily interested in the
+        # node counts.
+        es_clusterstats = get_json(r'http://%s:%d/%s_cluster/stats' %
+                                   (host, port, prefix))
+
         # Request a bunch of useful numbers that we export as perfdata.  
         # Details like the number of get, search, and indexing 
         # operations come from here.
@@ -154,32 +159,7 @@ class ElasticSearchCheck(NagiosCheck):
 
         n_nodes = es_health['number_of_nodes']
         n_dnodes = es_health['number_of_data_nodes']
-
-        # Unlike n_dnodes (the number of data nodes), we must compute 
-        # the number of master-eligible nodes ourselves.
-        n_mnodes = 0
-        for esid in es_state['nodes']:
-            master_elig = True
-
-            # ES will never elect 'client' nodes as masters.
-            try:
-                master_elig = not (booleanise(
-                    es_state['nodes'][esid]['attributes']
-                    ['client']))
-            except KeyError, e:
-                if e.args[0] != 'client':
-                    raise
-
-            try:
-                master_elig = (booleanise(
-                    es_state['nodes'][esid]['attributes']
-                    ['master']))
-            except KeyError, e:
-                if e.args[0] != 'master':
-                    raise
-
-            if master_elig:
-                n_mnodes += 1
+        n_mnodes = es_clusterstats['nodes']['count']['master_only'] + es_clusterstats['nodes']['count']['master_data']
 
         n_active_shards = es_health['active_shards']
         n_relocating_shards = es_health['relocating_shards']


### PR DESCRIPTION
This adds fetching of _cluster/stats, then calculates n_mnodes as the sum of master_only and master_data node counts. Would it be correct to do it this way?