### PR TITLE
fixed default prefix handling for ES 5.x compatibility (fixes #43)

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -96,7 +96,7 @@ class ElasticSearchCheck(NagiosCheck):
         host = opts.host or "localhost"
         port = int(opts.port or '9200')
         prefix = opts.prefix or ""
-        if not prefix.endswith('/'):
+        if len(prefix) > 0 and not prefix.endswith('/'):
             prefix += '/'
 
         failure_domain = []


### PR DESCRIPTION
Note: This PR just handles the prefix handling.

The "stats" parameter handling - as mentioned by @darnux - is untouched.