### PR TITLE
Remove ?all=true to stats query

### DIFF
--- a/check_elasticsearch
+++ b/check_elasticsearch
@@ -148,7 +148,7 @@ class ElasticSearchCheck(NagiosCheck):
         # Details like the number of get, search, and indexing 
         # operations come from here.
         es_stats = get_json(r'http://%s:%d/%s_nodes/_local/'
-                            'stats?all=true' % (host, port, prefix))
+                            'stats' % (host, port, prefix))
 
         myid = es_stats['nodes'].keys()[0]
 


### PR DESCRIPTION
The ?stats=all parameter is invalid in ES 5.x

Fixes #43 